### PR TITLE
fix the calculation of global map dissilarity when using more than 1 trial

### DIFF
--- a/MST1.0/MicroStats.m
+++ b/MST1.0/MicroStats.m
@@ -39,8 +39,8 @@
 % Authors:
 %
 % Andreas Pedroni, andreas.pedroni@uzh.ch
-% University of Zürich, Psychologisches Institut, Methoden der
-% Plastizitätsforschung.
+% University of Zï¿½rich, Psychologisches Institut, Methoden der
+% Plastizitï¿½tsforschung.
 %
 % Andreas Trier Poulsen, atpo@dtu.dk
 % Technical University of Denmark, DTU Compute, Cognitive systems.
@@ -94,7 +94,7 @@ A_nrm = (A - repmat(mean(A,1), C, 1)) ./ repmat(std(A,1), C, 1);
 % Global map dissilarity
 GMD = nan(K,N);
 for k = 1:K
-    GMD(k,:) = sqrt(mean( (Xnrm - repmat(A_nrm(:,k),1,N)).^2 ));
+    GMD(k,:) = sqrt(mean( (Xnrm - repmat(A_nrm(:,k),1,N*Ntrials)).^2 ));
 end
 
 % Account for polarity (recommended 0 for spontaneous EEG)


### PR DESCRIPTION
Hi,

My name is Murilo Schaefer and I work at Brussels - Belgium. I've been working with your toolbox in the last week, really thanks for making it available.

I tried to follow your toolbox guide, but when I tried to generate the stats of the microstates I got an error with matrix dimensions. Then I looking more deeply and found that to calculate the Global map dissilarity you didn't take into account the number of trials, is it right?

I add the number of trials and it works perfectly after that. Could you check if it makes sense?

Thanks by the awesome toolbox,
Murilo Schaefer 