### PR TITLE
Fix polarity invariant GMD calculation and Implement trial aggregated transition probability

### DIFF
--- a/MST1.0/MicroStats.m
+++ b/MST1.0/MicroStats.m
@@ -281,6 +281,7 @@ for k = 1:K %for each MS class...
 end
 
 %% Transition Probabilities (as with hmmestimate(states,states);)
+TP_total = zeros(K);
 for trial = 1:Ntrials
     states = order{trial,:};
     states = states(states ~= 0);
@@ -293,11 +294,17 @@ for trial = 1:Ntrials
         tr(states(count),states(count+1)) = tr(states(count),states(count+1)) + 1;
     end
     trRowSum = sum(tr,2);
+    %aggregate transition frequenices across trials
+    TP_total = TP_total + tr;
     % if we don't have any values then report zeros instead of NaNs.
     trRowSum(trRowSum == 0) = -inf;
     % normalize to give frequency estimate.
     TP(:,:,trial) = tr./repmat(trRowSum,1,numStates);
 end
+%divide by rowsum after aggregation
+total_RowSum = sum(TP_total, 2);
+total_RowSum(total_RowSum == 0) = -inf;
+TP_total = TP_total ./ repmat(total_RowSum, 1, K);
 
 
 %% Write to EEG structure
@@ -326,6 +333,7 @@ if Ntrials > 1
     Mstats.avgs.Coverage = nanmean(TCov,1);
     Mstats.avgs.GEV = nanmean(GEV,1);
     Mstats.avgs.MspatCorr = nanmean(MspatCorr,1);
+    Mstats.avgs.TP = TP_total;
     
     % standard deviation of parameters
     Mstats.avgs.stdGfp = nanstd(MGFP);

--- a/MST1.0/MicroStats.m
+++ b/MST1.0/MicroStats.m
@@ -11,7 +11,8 @@
 %  Inputs:
 %   X - EEG (channels x samples (x trials)).
 %   A - Spatial distribution of microstate prototypes (channels x K).
-%   L - Label of the most active microstate at each timepoint (trials x
+%   L - Label of the most act
+ive microstate at each timepoint (trials x
 %       time).
 %
 %  Optional input:
@@ -39,7 +40,8 @@
 %  Mstats.raw - Structure of raw microstate parameters* per trial 
 %               (for duration, GFP, GEV and spatial correlation)
 %               *raw meaning calculated separately for each single
-%               occurring microstate
+%               occurring m
+icrostate
 %
 % Authors:
 %
@@ -118,7 +120,7 @@ end
 
 % Account for polarity (recommended 0 for spontaneous EEG)
 if polarity == 0
-    GMDinvpol = nan(K,N);
+    GMDinvpol = nan(K,N*Ntrials);
     for k = 1:K
         GMDinvpol(k,:) = sqrt(mean( (Xnrm - repmat(-A_nrm(:,k),1,size(Xnrm,2))).^2));
     end

--- a/MST1.0/MicroStats.m
+++ b/MST1.0/MicroStats.m
@@ -11,8 +11,7 @@
 %  Inputs:
 %   X - EEG (channels x samples (x trials)).
 %   A - Spatial distribution of microstate prototypes (channels x K).
-%   L - Label of the most act
-ive microstate at each timepoint (trials x
+%   L - Label of the most active microstate at each timepoint (trials x
 %       time).
 %
 %  Optional input:
@@ -40,8 +39,7 @@ ive microstate at each timepoint (trials x
 %  Mstats.raw - Structure of raw microstate parameters* per trial 
 %               (for duration, GFP, GEV and spatial correlation)
 %               *raw meaning calculated separately for each single
-%               occurring m
-icrostate
+%               occurring microstate
 %
 % Authors:
 %


### PR DESCRIPTION
Initial size of 'GMDinvpol' is incompatible for assignment. Fixed by accounting for number of trials. Also implements a trial aggregated transition probability calculation.